### PR TITLE
1.0.2

### DIFF
--- a/Carbon.Cryptography/Carbon.Cryptography.psd1
+++ b/Carbon.Cryptography/Carbon.Cryptography.psd1
@@ -17,7 +17,7 @@
     RootModule = 'Carbon.Cryptography.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.1'
+    ModuleVersion = '1.0.2'
 
     # ID used to uniquely identify this module
     GUID = '225b9f63-3e3e-406c-87a0-33d34f30cd8e'
@@ -134,8 +134,7 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Fixed: `Protect-CString` incorrectly marked as a filter instead of a function.
-* Fixed: `Protect-CString` and `Unprotect-CString` failed to handle encryption exceptions.
+* Fixed: `Unprotect-CString` error handling fails when encryption fails.
 '@
         } # End of PSData hashtable
 

--- a/Carbon.Cryptography/Functions/Unprotect-CString.ps1
+++ b/Carbon.Cryptography/Functions/Unprotect-CString.ps1
@@ -258,8 +258,9 @@ function Unprotect-CString
                 $isRsa = $privateKeyType.IsSubclassOf([Security.Cryptography.RSA])
                 if( -not $isRsa )
                 {
-                    $msg = "$($certDesc) is not an RSA key. Found a private key of type ""$($privateKeyType.FullName)"", but " +
-                        "expected type ""$([Security.Cryptography.RSA].FullName)"" or one of its sub-types."
+                    $msg = "$($certDesc) is not an RSA key. Found a private key of type " +
+                           """$($privateKeyType.FullName)"", but expected type " +
+                           """$([Security.Cryptography.RSA].FullName)"" or one of its sub-types."
                     Write-Error -Message $msg -ErrorAction $ErrorActionPreference
                     return
                 }
@@ -340,7 +341,7 @@ function Unprotect-CString
         }
         catch
         {
-            Write-Error -ErrorRecrd $_ -ErrorAction $ErrorActionPreference
+            Write-Error -ErrorRecord $_ -ErrorAction $ErrorActionPreference
         }
         finally
         {

--- a/Tests/Install-CCertificate.Tests.ps1
+++ b/Tests/Install-CCertificate.Tests.ps1
@@ -65,7 +65,17 @@ function ThenCertificateInstalled
         $In = 'My'
     )
 
-    $cert = Get-CCertificate -Thumbprint $WithThumbprint -StoreLocation $For -StoreName $In
+    $tries = 100
+    $cert = $null
+    for( $tryNum = 0; $tryNum -lt $tries; ++$tryNum )
+    {
+        $cert = Get-CCertificate -Thumbprint $WithThumbprint -StoreLocation $For -StoreName $In
+        if( $cert )
+        {
+            break
+        }
+        Start-Sleep -Milliseconds 100
+    }
     $cert | Should -Not -BeNullOrEmpty
     $cert.Thumbprint | Should -Be $WithThumbprint
 }

--- a/Tests/Protect-CString.Tests.ps1
+++ b/Tests/Protect-CString.Tests.ps1
@@ -231,3 +231,22 @@ foreach( $keySize in @( 128, 192, 256 ) )
         }
     }
 }
+
+Describe 'Protect-CString.when encryption fails' {
+    # Anyone know how to get DPAPI or AES encryption to fail?
+    Context 'RSA' {
+        It 'should fail' {
+            { 
+                $Global:Error.Clear()
+                # Definitely too big to be encrypted by RSA.
+                $plainText = 'a' * 1000
+                Protect-CString -String $plainText -PublicKeyPath $publicKeyFilePath -ErrorAction SilentlyContinue |
+                    Should -BeNullOrEmpty
+                # Different error message on different versions of .NET and different platforms
+                #                              WinPS 5.1 | PS Core 7            | Linux        | macOS
+                $Global:Error | Should -Match 'Bad Length|parameter is incorrect|data too large|message exceeds the maximum'
+            } |
+                Should -Not -Throw
+        }
+    }
+}


### PR DESCRIPTION
Fixed: Unprotect-CString error handling fails when encryption fails. This is why test coverage is important.