### PR TITLE
Fix edge case failure in Unprotect-CString

### DIFF
--- a/Carbon.Cryptography/Carbon.Cryptography.psd1
+++ b/Carbon.Cryptography/Carbon.Cryptography.psd1
@@ -17,7 +17,7 @@
     RootModule = 'Carbon.Cryptography.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.3'
+    ModuleVersion = '1.0.4'
 
     # ID used to uniquely identify this module
     GUID = '225b9f63-3e3e-406c-87a0-33d34f30cd8e'
@@ -134,10 +134,8 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Fixed: When installing certificates with private keys, the `Install-CCertificate` function causes Windows API to write
-extra files to the directories where private keys are saved.
-* Fixed: In some situations, the `Install-CCertificate` function, when passed a certificate object to install with a
-private key, would fail to install the private key.
+* Fixed: Unprotect-CString sometimes fails to decrypt a secret if the decryption key certificate is installed in
+  multiple certificate stores but some of those times without the private key.
 '@
         } # End of PSData hashtable
 

--- a/Carbon.Cryptography/Functions/Unprotect-CString.ps1
+++ b/Carbon.Cryptography/Functions/Unprotect-CString.ps1
@@ -180,7 +180,7 @@ function Unprotect-CString
 
         [byte[]]$keyBytes = [byte[]]::New(0)
 
-        # Find and validate the RSA certificate, if needed. We do it here so our try/catch around the actual 
+        # Find and validate the RSA certificate, if needed. We do it here so our try/catch around the actual
         # decryption doesn't handle these errors.
         if( $PSCmdlet.ParameterSetName -like 'RSA*' )
         {
@@ -201,10 +201,22 @@ function Unprotect-CString
                 $count = $certificates | Measure-Object | Select-Object -ExpandProperty 'Count'
                 if( $count -gt 1 )
                 {
-                    $msg = "Found $($count) certificates at ""$($PrivateKeyPath)"". Arbitrarily choosing the first " +
-                        'one. If you get errors, consider passing the exact path to the certificate you want to ' +
-                        'the "Unprotect-CString" function''s "PrivateKeyPath" parameter.'
-                    Write-Warning -Message $msg
+                    $certificates = $certificates | Where-Object { $_.HasPrivateKey -and $_.PrivateKey }
+                    $privateKeyCount = $certificates | Measure-Object | Select-Object -ExpandProperty 'Count'
+
+                    if( $privateKeyCount -gt 1 )
+                    {
+                        $msg = "Found $($privateKeyCount) certificates (which contain private keys) at ""$($PrivateKeyPath)"". " +
+                            'Arbitrarily choosing the first one. If you get errors, consider passing the exact path to ' +
+                            'the certificate you want to the "Unprotect-CString" function''s "PrivateKeyPath" parameter.'
+                        Write-Warning -Message $msg
+                    }
+                    elseif( $privateKeyCount -eq 0 )
+                    {
+                        "Found $($count) certificates at ""$($PrivateKeyPath)"" but none of them contain a private " +
+                        'key or the private key is null.' | Write-Error
+                        return
+                    }
                 }
                 $Certificate = $certificates | Select-Object -First 1
                 if( -not $Certificate )

--- a/Carbon.Cryptography/Functions/Unprotect-CString.ps1
+++ b/Carbon.Cryptography/Functions/Unprotect-CString.ps1
@@ -213,8 +213,17 @@ function Unprotect-CString
                     }
                     elseif( $privateKeyCount -eq 0 )
                     {
+
+                        $installedInCertStoreMsg = ''
+                        if ($PSCmdlet.ParameterSetName -eq 'RSAByThumbprint')
+                        {
+                            $installedInCertStoreMsg =
+                                'This is usually because the certificate was installed without a private key or the ' +
+                                'current user doesn''t have permission to read the private key.'
+                        }
+
                         "Found $($count) certificates at ""$($PrivateKeyPath)"" but none of them contain a private " +
-                        'key or the private key is null.' | Write-Error
+                        "key or the private key is null.$(' ' + $installedInCertStoreMsg)" | Write-Error
                         return
                     }
                 }

--- a/Tests/Unprotect-CString.Tests.ps1
+++ b/Tests/Unprotect-CString.Tests.ps1
@@ -14,9 +14,38 @@ $privateKey2Path = Join-Path -Path $PSScriptRoot -ChildPath 'Resources\CarbonTes
 
 $rsaCipherText = Protect-CString -String $secret -PublicKeyPath $privateKeyPath
 
+function Reset
+{
+    # Uninstall-CCertificate doesn't work on Windows yet
+    if( (Test-COperatingSystem -IsWindows) )
+    {
+        # Uninstall the test certs from all locations and stores
+        $certsToUninstall = @($publicKeyPath, $publicKey2Path)
+        foreach ($cert in $certsToUninstall)
+        {
+            $thumbprint = Get-CCertificate -Path $cert | Select-Object -ExpandProperty 'Thumbprint'
+            $storeLocations = [enum]::GetValues([System.Security.Cryptography.X509Certificates.StoreLocation])
+
+            foreach ($location in $storeLocations)
+            {
+                $storeNames = [enum]::GetValues([System.Security.Cryptography.X509Certificates.StoreName])
+
+                foreach ($name in $storeNames)
+                {
+                    Uninstall-CCertificate -Thumbprint $thumbprint -StoreLocation $location -StoreName $name
+                }
+            }
+        }
+    }
+}
+
 Describe 'Unprotect-CString' {
     BeforeEach {
         $Global:Error.Clear()
+    }
+
+    AfterEach {
+        Reset
     }
 
     if( (Test-COperatingSystem -IsWindows) )
@@ -51,13 +80,21 @@ Describe 'Unprotect-CString' {
             $secrets[3] | Convert-CSecureStringToString | Should -Be 'Bar'
         }
 
+        It 'should convert to plain text' {
+            $originalText = [Guid]::NewGuid().ToString()
+            $protectedText = Protect-CString -String $originalText -ForUser
+            $plainText = Unprotect-CString -ProtectedString $protectedText -AsPlainText
+            $plainText | Should -BeOfType ([String])
+            $plainText | Should -Be $originalText
+        }
+
         It 'should handle thumbprint to cert with no private key' {
-            $cert = Get-ChildItem -Path 'cert:\*\*' -Recurse |
-                        Where-Object { $_.PublicKey.Key -is [Security.Cryptography.RSA] } |
-                        Where-Object { -not $_.HasPrivateKey } |
-                        Select-Object -First 1
+            $cert = Install-CCertificate -Path $publicKeyPath -StoreLocation CurrentUser -StoreName My -PassThru
             $cert | Should -Not -BeNullOrEmpty
-            $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText -Thumbprint $cert.Thumbprint -ErrorAction SilentlyContinue
+            $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText `
+                                                -Thumbprint $cert.Thumbprint `
+                                                -ErrorAction SilentlyContinue `
+                                                -WarningAction SilentlyContinue
             $Global:Error.Count | Should -BeGreaterThan 0
             $Global:Error[0] | Should -Match 'doesn''t have a private key'
             $revealedSecret | Should -BeNullOrEmpty
@@ -65,38 +102,49 @@ Describe 'Unprotect-CString' {
 
         It 'should decrypt with path to cert in store' {
             $cert = Install-CCertificate -Path $privateKeyPath -StoreLocation CurrentUser -StoreName My -PassThru
-            try
-            {
-                $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText -PrivateKeyPath ('cert:\CurrentUser\My\{0}' -f $cert.Thumbprint)
-                $Global:Error.Count | Should -Be 0
-                $revealedSecret | Convert-CSecureStringToString | Should -Be $secret
-            }
-            finally
-            {
-                Uninstall-CCertificate -Thumbprint $cert.Thumbprint -StoreLocation CurrentUser -StoreName My
-            }
+            $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText -PrivateKeyPath ('cert:\CurrentUser\My\{0}' -f $cert.Thumbprint)
+            $Global:Error.Count | Should -Be 0
+            $revealedSecret | Convert-CSecureStringToString | Should -Be $secret
         }
 
         It 'should decrypt with thumbprint' {
             $cert = Install-CCertificate -Path $privateKeyPath -StoreLocation CurrentUser -StoreName My -PassThru
-            try
-            {
-                $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText -Thumbprint $cert.Thumbprint
-                $Global:Error.Count | Should -Be 0
-                $revealedSecret | Convert-CSecureStringToString | Should -Be $secret
-            }
-            finally
-            {
-                Uninstall-CCertificate -Thumbprint $cert.Thumbprint -StoreLocation CurrentUser -StoreName My
-            }
+            $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText -Thumbprint $cert.Thumbprint
+            $Global:Error.Count | Should -Be 0
+            $revealedSecret | Convert-CSecureStringToString | Should -Be $secret
         }
 
-        It 'should convert to plain text' {
-            $originalText = [Guid]::NewGuid().ToString()
-            $protectedText = Protect-CString -String $originalText -ForUser
-            $plainText = Unprotect-CString -ProtectedString $protectedText -AsPlainText
-            $plainText | Should -BeOfType ([String])
-            $plainText | Should -Be $originalText
+        It 'should handle when cert is installed multiple times with private key' {
+            $cert = Install-CCertificate -Path $privateKeyPath -StoreLocation CurrentUser -StoreName My -PassThru
+            $null = Install-CCertificate -Path $privateKeyPath -StoreLocation CurrentUser -StoreName CertificateAuthority
+
+            $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText `
+                                                -Thumbprint $cert.Thumbprint `
+                                                -WarningVariable 'warnings' `
+                                                -WarningAction SilentlyContinue
+            $Global:Error.Count | Should -Be 0
+            $revealedSecret | Convert-CSecureStringToString | Should -Be $secret
+            $warnings | Should -Match '^Found 2 certificates'
+        }
+
+        It 'should handle when cert is installed multiple times, once without the private key' {
+            $cert = Install-CCertificate -Path $privateKeyPath -StoreLocation CurrentUser -StoreName My -PassThru
+            $null = Install-CCertificate -Path $publicKeyPath -StoreLocation CurrentUser -StoreName CertificateAuthority
+
+            $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText -Thumbprint $cert.Thumbprint -WarningVariable 'warnings'
+            $Global:Error.Count | Should -Be 0
+            $revealedSecret | Convert-CSecureStringToString | Should -Be $secret
+            $warnings | Should -BeNullOrEmpty
+        }
+
+        It 'should handle when cert is installed multiple times, all without the private key' {
+            $cert = Install-CCertificate -Path $publicKeyPath -StoreLocation CurrentUser -StoreName My -PassThru
+            $null = Install-CCertificate -Path $publicKeyPath -StoreLocation CurrentUser -StoreName CertificateAuthority
+
+            $revealedSecret = Unprotect-CString -ProtectedString $rsaCipherText -Thumbprint $cert.Thumbprint -ErrorAction SilentlyContinue
+            $Global:Error.Count | Should -BeGreaterThan 0
+            $Global:Error[0] | Should -Match '^Found 2 certificates at ".+" but none of them contain a private key or the private key is null'
+            $revealedSecret | Should -BeNullOrEmpty
         }
     }
 
@@ -164,22 +212,14 @@ Describe 'Unprotect-String.AES' {
     }
 }
 
-if( (Test-Path -Path 'cert:') )
-{
-    $certWithEmptyPrivateKey = 
-        Get-ChildItem -Path 'cert:\*\*\*' |
-        Where-Object 'HasPrivateKey' -eq $true |
-        Where-Object 'PrivateKey' -eq $null |
-        Select-Object -First 1
+Describe 'Unprotect-CString.when user does not have access to private key' {
+    It 'should fail' {
+        $cert = Get-CCertificate -Path $privateKeyPath
+        $cert | Add-member -MemberType NoteProperty -Name 'PrivateKey' -Value $null -Force
+        $cert | Add-Member -MemberType NoteProperty -Name 'HasPrivateKey' -Value $true -Force
 
-    if( $certWithEmptyPrivateKey )
-    {
-        Describe 'Unprotect-CString.when user does not have access to private key' {
-            It 'should fail' {
-                { Unprotect-CString -ProtectedString 'doesn''t matter' -Thumbprint $certWithEmptyPrivateKey.Thumbprint -ErrorAction Stop } |
-                    Should -Throw 'has a private key, but it is null'
-            }
-        }
+        { Unprotect-CString -ProtectedString 'doesn''t matter' -Certificate $cert -ErrorAction Stop } |
+            Should -Throw 'has a private key, but it is null'
     }
 }
 
@@ -188,7 +228,7 @@ Describe 'Unprotect-CString.when decryption fails' {
     {
         Context 'DPAPI' {
             It 'should fail' {
-                { 
+                {
                     $Global:Error.Clear()
                     Unprotect-CString -ProtectedString 'not encrypted' -ErrorAction SilentlyContinue |
                         Should -BeNullOrEmpty
@@ -200,7 +240,7 @@ Describe 'Unprotect-CString.when decryption fails' {
     }
     Context 'RSA' {
         It 'should fail' {
-            { 
+            {
                 $Global:Error.Clear()
                 Unprotect-CString -ProtectedString 'not encrypted' `
                                   -PrivateKeyPath $privateKeyPath `
@@ -214,7 +254,7 @@ Describe 'Unprotect-CString.when decryption fails' {
     }
     Context 'AES' {
         It 'should fail' {
-            { 
+            {
                 $Global:Error.Clear()
                 $key = 'passwordpasswordpasswordpassword'
                 $fakeCipherText =

--- a/init.ps1
+++ b/init.ps1
@@ -30,7 +30,7 @@ $passwordPath = Join-Path -Path $PSScriptRoot -ChildPath 'Tests\.password'
 if( -not (Test-Path -Path $passwordPath) )
 {
     $rng = [Security.Cryptography.RNGCryptoServiceProvider]::New()
-    $randomBytes = [byte[]]::New(9)
+    $randomBytes = [byte[]]::New(12)
     do 
     {
         Write-Verbose -Message ('Generating random password for test accounts.')
@@ -38,7 +38,7 @@ if( -not (Test-Path -Path $passwordPath) )
         $password = [Convert]::ToBase64String($randomBytes)
     }
     # Password needs to contain uppercase letter, lowercase letter, and a number.
-    while( $password -cnotmatch '[A-Z]' -and $password -cnotmatch '[a-z]' -and $password -notmatch '\d' )
+    while( $password -cnotmatch '[A-Z]' -and $password -cnotmatch '[a-z]' -and $password -notmatch '\d' -and $password -notmatch '\+|\/' )
     $password | Set-Content -Path $passwordPath
 
     Write-Verbose -Message ('Generating IV for encrypting test account password on Linux.')


### PR DESCRIPTION
Fixed: Unprotect-CString sometimes fails to decrypt a secret if the decryption key certificate is installed in multiple certificate stores but some of those times without the private key.