### PR TITLE
Migrate New-CRsaKeyPair from Carbon and create signing certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ you would change it to:
 If you have automation that installs modules with `Install-Module`, you may need to add the `-AllowClobber` switch if
 you've got previous versions of Carbon.Cryptography or Carbon installed.
 
+## Added
+
+Copied the `New-CRsaKeyPair` function from Carbon. This function generates a public/private key pair suitable for
+document encryption, including in DSC resources and PowerShell's CMS message cmdlets.
+
 ## Changes
 
 Added a `C` prefix to each command and removed the `DefaultCommandPrefix`. PowerShell won't auto-load a module that uses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Upgrade Instructions
 
+### From Previous Versions of Carbon.Cryptography
+
 It turns out, PowerShell doesn't find and auto-load modules that use the `DefaultCommandPrefix` setting. So, we've 
 removed `Carbon.Cryptography` module's `DefaultCommandPrefix` and explicitly added a `C` prefix to all commands. 
 
@@ -19,15 +21,41 @@ you would change it to:
 If you have automation that installs modules with `Install-Module`, you may need to add the `-AllowClobber` switch if
 you've got previous versions of Carbon.Cryptography or Carbon installed.
 
+### From Carbon
+
+Add a `-KeyUsage DocumentEncryption` argument to usages of `New-CRsaKeyPair`. The `KeyUsage` parameter was added and if
+not given, `New-CRsaKeyPair` generates a key pair with no key usages or enhanced key usages. To create a key pair for
+speific usages, valid usages are `ClientAuthentication`, `CodeSigning`, `DocumentEncryption`, `DocumentSigning`, and
+`ServerAuthentication`.
+
+Remove all usages of the `New-CRsaKeyPair` function's `ValidFrom` and `Authority` parameters. They were removed.
+
+`New-CRsaKeyPair` used to return two `[IO.FileInfo]` objects: the generated public key and private key. It now returns
+one object that has `PublicKeyFile` and `PrivateKeyFile` properties instead. Update usages.
+
 ## Added
 
-Copied the `New-CRsaKeyPair` function from Carbon. This function generates a public/private key pair suitable for
+* Copied the `New-CRsaKeyPair` function from Carbon. This function generates a public/private key pair suitable for
 document encryption, including in DSC resources and PowerShell's CMS message cmdlets.
+* Added anew `KeyUsage` parameter to `New-CRsaKeyPair`. When not given, certificates with no key usages or enhanced key
+usages are created. Pass the key's usages to this parameter. Valid usages are `ClientAuthentication`, `CodeSigning`,
+`DocumentEncryption`, `DocumentSigning`, and `ServerAuthentication`.
 
 ## Changes
 
-Added a `C` prefix to each command and removed the `DefaultCommandPrefix`. PowerShell won't auto-load a module that uses
+* Added a `C` prefix to each command and removed the `DefaultCommandPrefix`. PowerShell won't auto-load a module that uses
 a default command prefix and you call the command with the prefix.
+* The `New-CRsaKeyPair` default parameter set creates a key pair with no key usages or enhanced key usages. Previous
+versions created a key pair for document encryption. To get previous default behavior, add
+`-KeyUsage DocumentEncryption` argument to all `New-CRsaKeyPair` usages.
+* The `NewCRsaKeyPair` function no longer returns two `IO.FileInfo` objects for the public and private key files.
+Instead, it returns an object with `PrivateKeyFile` and `PublicKeyFile` properties, which are `[IO.FileInfo]` objects
+for the public and private key, respectively.
+
+## Fixes
+
+* Fixed: `New-CRsaKeyPair` function fails when public/private key files already exist, even if using the `-Force`
+parameter.
 
 
 # 2.3.0

--- a/Carbon.Cryptography/Carbon.Cryptography.psd1
+++ b/Carbon.Cryptography/Carbon.Cryptography.psd1
@@ -83,6 +83,7 @@
         'Find-CTlsCertificate',
         'Get-CCertificate',
         'Install-CCertificate',
+        'New-CRsaKeyPair',
         'Protect-CString',
         'Uninstall-CCertificate',
         'Unprotect-CString'

--- a/Carbon.Cryptography/Functions/New-CRsaKeyPair.ps1
+++ b/Carbon.Cryptography/Functions/New-CRsaKeyPair.ps1
@@ -208,9 +208,12 @@ function New-CRsaKeyPair
 
     try
     {
-        $certReqPath = Get-Command -Name 'certreq.exe' | Select-Object -ExpandProperty 'Path'
+        $certReqPath = Get-Command -Name 'certreq.exe' -ErrorAction Ignore | Select-Object -ExpandProperty 'Path'
         if( -not $certReqPath )
         {
+            'Command "certreq.exe" does not exist. This is a Windows-only command. If you''re on Windows, make sure ' +
+            '"C:\Windows\System32" is part of your "Path" environment variable.' |
+                Write-Error -ErrorAction $ErrorActionPreference
             return
         }
 

--- a/Carbon.Cryptography/Functions/New-CRsaKeyPair.ps1
+++ b/Carbon.Cryptography/Functions/New-CRsaKeyPair.ps1
@@ -7,35 +7,23 @@ function New-CRsaKeyPair
 
     .DESCRIPTION
     The `New-CRsaKeyPair` function uses the `certreq.exe` program to generate an RSA public/private key pair suitable
-    for use in encrypting/decrypting CMS messages, credentials in DSC resources, etc. It uses the following `.inf` file
-    as input (taken from the first example in the help for the `Protect-CmsMessage` cmdlet):
+    for use in encrypting/decrypting CMS messages, credentials in DSC resources, etc.
 
-        [Version]
-        Signature = "$Windows NT$"
+    Pass the subject to the `Subject` parameter (it must begin with `CN=`) and the paths where you want the public and
+    private keys saved to the `PublicKeyPath` and `PrivateKeyPath` parameters, respectively. `New-CRsaKeyPair` creates
+    a temporary .inf file and passes it to the `certreq.exe` program. You will be prompted for a password, unless you
+    pass a password to the `Password` parameter.
+    
+    By default, a key pair with no key usages or enhanced key usages is generated that is 4096 bits in length, uses
+    `SHA512` as the signature/hash algorithm, and is valid until December 31st, 9999. An object with
+    `[IO.FileInfo] PublicKeyFile` and `[IO.FileInfo] PrivateKeyFile` properties is returned.
 
-        [Strings]
-        szOID_ENHANCED_KEY_USAGE = "2.5.29.37"
-        szOID_DOCUMENT_ENCRYPTION = "1.3.6.1.4.1.311.80.1"
+    You can change the key's length, algorithm, and expiration data with the `Length`, `Algorithm`, and `ValidTo`
+    parameters. You can set the key pair's usages with the `KeyUsage` parameter. Valid usages this function supports
+    are `ClientAuthentication`, `CodeSigning`, `DocumentEncryption`, `DocumentSigning`, and `ServerAuthentication`.
 
-        [NewRequest]
-        Subject = $Subject
-        MachineKeySet = false
-        KeyLength = $Length
-        KeySpec = AT_KEYEXCHANGE
-        HashAlgorithm = $Algorithm
-        Exportable = true
-        RequestType = Cert
-        KeyUsage = "CERT_KEY_ENCIPHERMENT_KEY_USAGE | CERT_DATA_ENCIPHERMENT_KEY_USAGE"
-        ValidityPeriod = Days
-        ValidityPeriodUnits = 
-
-        [Extensions]
-        %szOID_ENHANCED_KEY_USAGE% = "{{text}}%szOID_DOCUMENT_ENCRYPTION%"
-
-    You can control the subject (via the `-Subject` parameter), key length (via the `-Length` parameter), the hash
-    algorithm (via the `-Algorithm` parameter), and the expiration date of the keys (via the `-ValidTo` parameter). The
-    subject is always required and should begin with "CN=". The length, hash algorithm, and expiration date are
-    optional, and default to `4096`, `sha512`, and `12/31/9999`, respectively.
+    If the destination files already exist, you'll get an error and no keys will be generated. Use the `Force` switch to
+    overwrite any existing files.
 
     The `certreq.exe` command stores the private key in the current user's `My` certificate store. This function exports
     that private key to a file and removes it from the current user's `My` store. The private key is protected with the
@@ -44,13 +32,6 @@ function New-CRsaKeyPair
 
     The public key is saved as an X509Certificate. The private key is saved as a PFX file. Both can be loaded by .NET's
     `X509Certificate` class. Returns `System.IO.FileInfo` objects for the public and private key, in that order.
-
-    Before Carbon 2.1, this function used the `makecert.exe` and `pvk2pfx.exe` programs, from the Windows SDK. These
-    programs prompt multiple times for the private key password, so if you're using a version before 2.1, you can't run
-    this function non-interactively. 
-
-    .OUTPUTS
-    System.IO.FileInfo
 
     .LINK
     Get-CCertificate
@@ -64,7 +45,7 @@ function New-CRsaKeyPair
     Demonstrates the minimal parameters needed to generate a key pair. The key will use a sha512 signing algorithm, have
     a length of 4096 bits, and expire on `12/31/9999`. The public key will be saved in the current directory as
     `MyName.cer`. The private key will be saved to the current directory as `MyName.pfx` and protected with password in
-    `$secureString`.
+    `$secureString`. The key pair will have no usages, so you won't be able to do much with it.
 
     .EXAMPLE
     New-CRsaKeyPair -Subject 'CN=MyName' -PublicKeyFile 'MyName.cer' -PrivateKeyFile 'MyName.pfx' -Password $null
@@ -73,13 +54,12 @@ function New-CRsaKeyPair
     `$null`. This functionality was introduced in Carbon 2.1.
 
     .EXAMPLE
-    New-CRsaKeyPair -Subject 'CN=MyName' -PublicKeyFile 'MyName.cer' -PrivateKeyFile 'MyName.pfx' -Algorithm 'sha1' -ValidTo (Get-Date -Year 2015 -Month 12 -Day 31) -Length 1024 -Password $secureString
+    New-CRsaKeyPair -Subject 'CN=MyName' -PublicKeyFile 'MyName.cer' -PrivateKeyFile 'MyName.pfx' -Algorithm 'sha1' -ValidTo (Get-Date -Year 2015 -Month 12 -Day 31) -Length 1024 -Password $secureString -KeyUsage DocumentSigning, DocumentEncryption
 
     Demonstrates how to use all the parameters to create a truly customized key pair. The generated certificate will use
-    the sha1 signing algorithm, becomes effective 1/1/2015, expires 12/31/2015, and is 1024 bits in length.
+    the sha1 signing algorithm, expires 12/31/2015, is 1024 bits in length, and can be used to sign and encrypt.
     #>
     [CmdletBinding()]
-    [OutputType([IO.FileInfo])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
     param(
         # The key's subject. Should be of the form `CN=Name,OU=Name,O=SuperMagicFunTime,ST=OR,C=US`. Only the `CN=Name`
@@ -92,25 +72,16 @@ function New-CRsaKeyPair
         [ValidateSet('md5', 'sha1', 'sha256', 'sha384', 'sha512')]
         [string] $Algorithm = 'sha512',
 
-        # The date/time the keys will become valid. Default is now. 
-        #
-        # This parameter was made obsolete in Carbon 2.1.
-        [Parameter(DontShow)]
-        [DateTime] $ValidFrom = (Get-Date),
-
         # The date/time the keys should expire. Default is `DateTime::MaxValue`.
         [DateTime] $ValidTo = ([DateTime]::MaxValue),
 
         # The length, in bits, of the generated key length. Default is `4096`.
         [int] $Length = 4096,
 
-        # The signing authority of the certificate. Must be `commercial` (for certificates used by commercial software
-        # publishers) or `individual`, for certificates used by individual software publishers. Default is `individual`.
-        #
-        # This parameter was made obsolete in Carbon 2.1.
-        [Parameter(DontShow)]
-        [ValidateSet('commercial', 'individual')]
-        [string] $Authority = 'individual',
+        # What extended key usages the certificate will have. By default, it will be for any purpose (OID 2.5.29.37.0).
+        [ValidateSet('ClientAuthentication', 'CodeSigning', 'DocumentEncryption', 'DocumentSigning',
+                     'ServerAuthentication')]
+        [String[]] $KeyUsage,
 
         # The file where the public key should be stored. Saved as an X509 certificate.
         [Parameter(Mandatory, Position=1)]
@@ -133,16 +104,6 @@ function New-CRsaKeyPair
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -Session $ExecutionContext.SessionState
-
-    if( $PSBoundParameters.ContainsKey('ValidFrom') )
-    {
-        Write-CWarningOnce -Message ('New-CRsaKeyPair: The -ValidFrom parameter is obsolete and will be removed in a future version of Carbon. Please remove usages of this parameter.')
-    }
-
-    if( $PSBoundParameters.ContainsKey('Authority') )
-    {
-        Write-CWarningOnce -Message ('New-CRsaKeyPair: The -Authority parameter is obsolete and will be removed in a future version of Carbon. Please remove usages of this parameter.')
-    }
 
     function Resolve-KeyPath
     {
@@ -201,6 +162,50 @@ function New-CRsaKeyPair
     New-Item -Path $tempDir -ItemType 'Directory' | Out-Null
     $tempInfFile = Join-Path -Path $tempDir -ChildPath 'temp.inf'
 
+    # Adapted from
+    # * https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/certreq_1
+    # * https://docs.microsoft.com/en-us/windows/win32/api/certenroll/ne-certenroll-x509keyusageflags
+    # * https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509keyusageflags
+    # * https://omvs.de/2019/11/13/key-usage-extensions-at-x-509-certificates/
+    # CERT_DIGITAL_SIGNATURE_KEY_USAGE (0x80/128):
+    #   The key can be used as a digital signature. The key is used with a Digital Signature Algorithm (DSA) to support
+    #   services other than nonrepudiation, certificate signing, or revocation list signing. 
+    # CERT_NON_REPUDIATION_KEY_USAGE (0x40/64):
+    #   The key can be used for authentication. The key is used to verify a digital signature as part of a
+    #   nonrepudiation service that protects against false denial of action by a signing entity.
+    # CERT_KEY_ENCIPHERMENT_KEY_USAGE (0x20/32):
+    #   The key can be used for key encryption. The key is used for key transport. That is, the key is used to manage a
+    #   key passed from its point of origination to another point of use.
+    # CERT_DATA_ENCIPHERMENT_KEY_USAGE (0x10/16):
+    #   The key can be used for data encryption. The key is used to encrypt user data other than cryptographic keys.
+    # CERT_KEY_AGREEMENT_KEY_USAGE (8):
+    #   The key can be used to determine key agreement, such as a key created using the Diffie-Hellman key agreement
+    #   algorithm. The key agreement or key exchange protocol enables two or more
+    #   parties to negotiate a key value without transferring the key and without previously establishing a shared
+    #   secret.
+    # CERT_KEY_CERT_SIGN_KEY_USAGE (4):
+    #   The key can be used to sign certificates. The key is used to verify a certificate signature. This value can only
+    #   be used for certificates issued by certification authorities.
+    # CERT_OFFLINE_CRL_SIGN_KEY_USAGE (2):
+    #   The key can be used to sign a certificate revocation list (CRL). The key is used to verify an offline
+    #   certificate revocation list (CRL) signature.
+    # CERT_CRL_SIGN_KEY_USAGE (2):
+    #   The key can be used to sign a certificate revocation list (CRL). The key is used to verify a CRL signature.
+    # CERT_ENCIPHER_ONLY_KEY_USAGE (1):
+    #   The key can be used for encryption only. The key is used to encrypt data while performing key agreement. When
+    #   this value is specified, the CERT_KEY_AGREEMENT_KEY_USAGE value must also be specified.
+    # CERT_DECIPHER_ONLY_KEY_USAGE (0x8000/32768):
+    #   The key can be used for decryption only. The key is used to decrypt data while performing key agreement. When
+    #   this value is specified, the CERT_KEY_AGREEMENT_KEY_USAGE must also be specified.
+
+    $usageMap = @{
+        ClientAuthentication = @('CERT_DIGITAL_SIGNATURE_KEY_USAGE', 'CERT_KEY_ENCIPHERMENT_KEY_USAGE');
+        CodeSigning = 'CERT_DIGITAL_SIGNATURE_KEY_USAGE';
+        DocumentEncryption = @('CERT_KEY_ENCIPHERMENT_KEY_USAGE', 'CERT_DATA_ENCIPHERMENT_KEY_USAGE');
+        DocumentSigning = 'CERT_DIGITAL_SIGNATURE_KEY_USAGE';
+        ServerAuthentication = @('CERT_DIGITAL_SIGNATURE_KEY_USAGE', 'CERT_KEY_ENCIPHERMENT_KEY_USAGE');
+    }
+
     try
     {
         $certReqPath = Get-Command -Name 'certreq.exe' | Select-Object -ExpandProperty 'Path'
@@ -210,7 +215,7 @@ function New-CRsaKeyPair
         }
 
         # Taken from example 1 of the Protect-CmsMessage help topic.
-        [int]$daysValid = [Math]::Floor(($ValidTo - $ValidFrom).TotalDays)
+        [int]$daysValid = [Math]::Floor(($ValidTo - (Get-Date)).TotalDays)
         [int]$MaxDaysValid = [Math]::Floor(([DateTime]::MaxValue - [DateTime]::UtcNow).TotalDays)
         Write-Debug -Message ('Days Valid:              {0}' -f $daysValid)
         Write-Debug -Message ('Max Days Valid:          {0}' -f $MaxDaysValid)
@@ -219,33 +224,97 @@ function New-CRsaKeyPair
             Write-Debug -Message ('Adjusted Days Valid:     {0}' -f $daysValid)
             $daysValid = $MaxDaysValid
         }
-        (@'
+
+        $keyUsages = & {
+            foreach( $usage in $KeyUsage )
+            {
+                if( $usageMap.ContainsKey($usage) )
+                {
+                    $usageMap[$usage] | Write-Output
+                }
+            }
+        } | Select-Object -Unique
+
+        $extensions = & {
+            if( -not $KeyUsage )
+            {
+                return
+            }
+
+            foreach( $usage in $KeyUsage )
+            {
+                switch( $usage )
+                {
+                    'ClientAuthentication' { 'szOID_CLIENT_AUTHENTICATION' }
+                    'CodeSigning' { 'szOID_CODE_SIGNING' }
+                    'DocumentEncryption' { 'szOID_DOCUMENT_ENCRYPTION' }
+                    'DocumentSigning' { 'szOID_DOCUMENT_SIGNING' }
+                    'ServerAuthentication' { 'szOID_SERVER_AUTHENTICATION' }
+                }
+            }
+        }
+
+        $keySpec = 'AT_NONE'
+        if( $KeyUsage | Where-Object { $_ -like '*Signing' } )
+        {
+            $keySpec = 'AT_SIGNATURE'
+        }
+        if( $KeyUsage | Where-Object { $_ -notlike '*Signing' } )
+        {
+            $keySpec = 'AT_KEYEXCHANGE'
+        }
+
+        $keyUsageLine = ''
+        if( $keyUsages )
+        {
+            $keyUsageLine = "KeyUsage = ""$($keyUsages -join ' | ')"""
+        }
+
+        $extensionsLine = ''
+        if( $extensions )
+        {
+            $extensionsLine = $extensions -join "%,""$([Environment]::NewLine)_continue_ = ""%"
+            $extensionsLine = "%szOID_ENHANCED_KEY_USAGE% = ""{text}%$($extensionsLine)%"""
+        }
+        
+        @"
 [Version]
-Signature = "$Windows NT$"
+Signature = "`$Windows NT`$"
 
 [Strings]
-szOID_ENHANCED_KEY_USAGE = "2.5.29.37"
-szOID_DOCUMENT_ENCRYPTION = "1.3.6.1.4.1.311.80.1"
+szOID_ANY_PURPOSE = 2.5.29.37.0
+szOID_CLIENT_AUTHENTICATION = 1.3.6.1.5.5.7.3.2
+szOID_CODE_SIGNING = 1.3.6.1.5.5.7.3.3
+szOID_DOCUMENT_ENCRYPTION = 1.3.6.1.4.1.311.80.1
+szOID_DOCUMENT_SIGNING = 1.3.6.1.4.1.311.10.3.12
+szOID_ENHANCED_KEY_USAGE = 2.5.29.37
+szOID_SERVER_AUTHENTICATION = 1.3.6.1.5.5.7.3.1
 
 [NewRequest]
-Subject = "{0}"
+Subject = "$($Subject)"
 MachineKeySet = false
-KeyLength = {1}
-KeySpec = AT_KEYEXCHANGE
-HashAlgorithm = {2}
+KeyLength = $($Length)
+KeySpec = $($keySpec)
+HashAlgorithm = $($Algorithm)
 Exportable = true
 RequestType = Cert
-KeyUsage = "CERT_KEY_ENCIPHERMENT_KEY_USAGE | CERT_DATA_ENCIPHERMENT_KEY_USAGE"
 ValidityPeriod = Days
-ValidityPeriodUnits = {3}
+ValidityPeriodUnits = $($daysValid)
+$($keyUsageLine)
 
 [Extensions]
-%szOID_ENHANCED_KEY_USAGE% = "{{text}}%szOID_DOCUMENT_ENCRYPTION%"
-'@ -f $Subject,$Length,$Algorithm,$daysValid) | Set-Content -Path $tempInfFile
+$($extensionsLine)
+"@ | Set-Content -Path $tempInfFile
 
-        Get-Content -Raw -Path $tempInfFile | Write-Debug
+        Get-Content -Raw -Path $tempInfFile | Write-Verbose
 
-        $output = & $certReqPath -q -new $tempInfFile $PublicKeyFile 
+        $forceArg = ''
+        if( $Force )
+        {
+            $forceArg = ' -f'
+        }
+        Write-Debug "& ""$($certReqPath)"" -q$($forceArg) -new ""$($tempInfFile)"" ""$($PublicKeyFile)"""
+        $output = & $certReqPath -q ($forceArg.TrimStart()) -new $tempInfFile $PublicKeyFile 
         if( $LASTEXITCODE -or -not (Test-Path -Path $PublicKeyFile -PathType Leaf) )
         {
             Write-Error ('Failed to create public/private key pair:{0}{1}' -f ([Environment]::NewLine),($output -join ([Environment]::NewLine)))
@@ -287,8 +356,10 @@ ValidityPeriodUnits = {3}
             $privateCertBytes = $privateCert.Export( 'PFX', $Password )
             [IO.File]::WriteAllBytes( $PrivateKeyFile, $privateCertBytes )
 
-            Get-Item $PublicKeyFile
-            Get-Item $PrivateKeyFile
+            [pscustomobject]@{
+                'PublicKeyFile' = (Get-Item $PublicKeyFile);
+                'PrivateKeyFile' = (Get-Item $PrivateKeyFile);
+            } | Write-Output
         }
         finally
         {

--- a/Carbon.Cryptography/Functions/New-CRsaKeyPair.ps1
+++ b/Carbon.Cryptography/Functions/New-CRsaKeyPair.ps1
@@ -1,0 +1,302 @@
+
+function New-CRsaKeyPair
+{
+    <#
+    .SYNOPSIS
+    Generates a public/private RSA key pair.
+
+    .DESCRIPTION
+    The `New-CRsaKeyPair` function uses the `certreq.exe` program to generate an RSA public/private key pair suitable
+    for use in encrypting/decrypting CMS messages, credentials in DSC resources, etc. It uses the following `.inf` file
+    as input (taken from the first example in the help for the `Protect-CmsMessage` cmdlet):
+
+        [Version]
+        Signature = "$Windows NT$"
+
+        [Strings]
+        szOID_ENHANCED_KEY_USAGE = "2.5.29.37"
+        szOID_DOCUMENT_ENCRYPTION = "1.3.6.1.4.1.311.80.1"
+
+        [NewRequest]
+        Subject = $Subject
+        MachineKeySet = false
+        KeyLength = $Length
+        KeySpec = AT_KEYEXCHANGE
+        HashAlgorithm = $Algorithm
+        Exportable = true
+        RequestType = Cert
+        KeyUsage = "CERT_KEY_ENCIPHERMENT_KEY_USAGE | CERT_DATA_ENCIPHERMENT_KEY_USAGE"
+        ValidityPeriod = Days
+        ValidityPeriodUnits = 
+
+        [Extensions]
+        %szOID_ENHANCED_KEY_USAGE% = "{{text}}%szOID_DOCUMENT_ENCRYPTION%"
+
+    You can control the subject (via the `-Subject` parameter), key length (via the `-Length` parameter), the hash
+    algorithm (via the `-Algorithm` parameter), and the expiration date of the keys (via the `-ValidTo` parameter). The
+    subject is always required and should begin with "CN=". The length, hash algorithm, and expiration date are
+    optional, and default to `4096`, `sha512`, and `12/31/9999`, respectively.
+
+    The `certreq.exe` command stores the private key in the current user's `My` certificate store. This function exports
+    that private key to a file and removes it from the current user's `My` store. The private key is protected with the
+    password provided via the `-Password` parameter. If you don't provide a password, you will be prompted for one. To
+    not protect the private key with a password, pass `$null` as the value of the `-Password` parameter.
+
+    The public key is saved as an X509Certificate. The private key is saved as a PFX file. Both can be loaded by .NET's
+    `X509Certificate` class. Returns `System.IO.FileInfo` objects for the public and private key, in that order.
+
+    Before Carbon 2.1, this function used the `makecert.exe` and `pvk2pfx.exe` programs, from the Windows SDK. These
+    programs prompt multiple times for the private key password, so if you're using a version before 2.1, you can't run
+    this function non-interactively. 
+
+    .OUTPUTS
+    System.IO.FileInfo
+
+    .LINK
+    Get-CCertificate
+
+    .LINK
+    Install-CCertificate
+
+    .EXAMPLE
+    New-CRsaKeyPair -Subject 'CN=MyName' -PublicKeyFile 'MyName.cer' -PrivateKeyFile 'MyName.pfx' -Password $secureString
+
+    Demonstrates the minimal parameters needed to generate a key pair. The key will use a sha512 signing algorithm, have
+    a length of 4096 bits, and expire on `12/31/9999`. The public key will be saved in the current directory as
+    `MyName.cer`. The private key will be saved to the current directory as `MyName.pfx` and protected with password in
+    `$secureString`.
+
+    .EXAMPLE
+    New-CRsaKeyPair -Subject 'CN=MyName' -PublicKeyFile 'MyName.cer' -PrivateKeyFile 'MyName.pfx' -Password $null
+
+    Demonstrates how to save the private key unprotected (i.e. without a password). You must set the password to
+    `$null`. This functionality was introduced in Carbon 2.1.
+
+    .EXAMPLE
+    New-CRsaKeyPair -Subject 'CN=MyName' -PublicKeyFile 'MyName.cer' -PrivateKeyFile 'MyName.pfx' -Algorithm 'sha1' -ValidTo (Get-Date -Year 2015 -Month 12 -Day 31) -Length 1024 -Password $secureString
+
+    Demonstrates how to use all the parameters to create a truly customized key pair. The generated certificate will use
+    the sha1 signing algorithm, becomes effective 1/1/2015, expires 12/31/2015, and is 1024 bits in length.
+    #>
+    [CmdletBinding()]
+    [OutputType([IO.FileInfo])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
+    param(
+        # The key's subject. Should be of the form `CN=Name,OU=Name,O=SuperMagicFunTime,ST=OR,C=US`. Only the `CN=Name`
+        # part is required.
+        [Parameter(Mandatory, Position=0)]
+        [ValidatePattern('^CN=')]
+        [string] $Subject,
+
+        # The signature algorithm. Default is `sha512`.
+        [ValidateSet('md5', 'sha1', 'sha256', 'sha384', 'sha512')]
+        [string] $Algorithm = 'sha512',
+
+        # The date/time the keys will become valid. Default is now. 
+        #
+        # This parameter was made obsolete in Carbon 2.1.
+        [Parameter(DontShow)]
+        [DateTime] $ValidFrom = (Get-Date),
+
+        # The date/time the keys should expire. Default is `DateTime::MaxValue`.
+        [DateTime] $ValidTo = ([DateTime]::MaxValue),
+
+        # The length, in bits, of the generated key length. Default is `4096`.
+        [int] $Length = 4096,
+
+        # The signing authority of the certificate. Must be `commercial` (for certificates used by commercial software
+        # publishers) or `individual`, for certificates used by individual software publishers. Default is `individual`.
+        #
+        # This parameter was made obsolete in Carbon 2.1.
+        [Parameter(DontShow)]
+        [ValidateSet('commercial', 'individual')]
+        [string] $Authority = 'individual',
+
+        # The file where the public key should be stored. Saved as an X509 certificate.
+        [Parameter(Mandatory, Position=1)]
+        [string] $PublicKeyFile,
+
+        # The file where the private key should be stored. The private key will be saved as an X509 certificate in PFX
+        # format and will include the public key.
+        [Parameter(Mandatory, Position=2)]
+        [string] $PrivateKeyFile,
+
+        # The password for the private key. If one is not provided, you will be prompted for one. Pass `$null` to not
+        # protect your private key with a password.
+        #
+        # This parameter was introduced in Carbon 2.1.
+        [securestring] $Password,
+
+        # Overwrites `PublicKeyFile` and/or `PrivateKeyFile`, if they exist.
+        [Switch] $Force
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -Session $ExecutionContext.SessionState
+
+    if( $PSBoundParameters.ContainsKey('ValidFrom') )
+    {
+        Write-CWarningOnce -Message ('New-CRsaKeyPair: The -ValidFrom parameter is obsolete and will be removed in a future version of Carbon. Please remove usages of this parameter.')
+    }
+
+    if( $PSBoundParameters.ContainsKey('Authority') )
+    {
+        Write-CWarningOnce -Message ('New-CRsaKeyPair: The -Authority parameter is obsolete and will be removed in a future version of Carbon. Please remove usages of this parameter.')
+    }
+
+    function Resolve-KeyPath
+    {
+        param(
+            [Parameter(Mandatory)]
+            [string] $Path
+        )
+
+        Set-StrictMode -Version 'Latest'
+
+        $Path = [IO.Path]::GetFullPath($Path)
+
+        if( (Test-Path -Path $Path -PathType Leaf) )
+        {
+            if( -not $Force )
+            {
+                Write-Error ('File ''{0}'' exists. Use the -Force switch to overwrite.' -f $Path)
+                return
+            }
+        }
+        else
+        {
+            $root = Split-Path -Parent -Path $Path
+            if( -not (Test-Path -Path $root -PathType Container) )
+            {
+                New-Item -Path $root -ItemType 'Directory' -Force | Out-Null
+            }
+        }
+
+        return $Path
+    }
+
+    $PublicKeyFile = Resolve-KeyPath -Path $PublicKeyFile
+    if( -not $PublicKeyFile )
+    {
+        return
+    }
+
+    $PrivateKeyFile = Resolve-KeyPath -Path $PrivateKeyFile
+    if( -not $PrivateKeyFile )
+    {
+        return
+    }
+
+    if( (Test-Path -Path $PrivateKeyFile -PathType Leaf) )
+    {
+        if( -not $Force )
+        {
+            Write-Error ('Private key file ''{0}'' exists. Use the -Force switch to overwrite.' -f $PrivateKeyFile)
+            return
+        }
+    }
+
+    $tempDir = '{0}-{1}' -f (Split-Path -Leaf -Path $PSCommandPath),([IO.Path]::GetRandomFileName())
+    $tempDir = Join-Path -Path $env:TEMP -ChildPath $tempDir
+    New-Item -Path $tempDir -ItemType 'Directory' | Out-Null
+    $tempInfFile = Join-Path -Path $tempDir -ChildPath 'temp.inf'
+
+    try
+    {
+        $certReqPath = Get-Command -Name 'certreq.exe' | Select-Object -ExpandProperty 'Path'
+        if( -not $certReqPath )
+        {
+            return
+        }
+
+        # Taken from example 1 of the Protect-CmsMessage help topic.
+        [int]$daysValid = [Math]::Floor(($ValidTo - $ValidFrom).TotalDays)
+        [int]$MaxDaysValid = [Math]::Floor(([DateTime]::MaxValue - [DateTime]::UtcNow).TotalDays)
+        Write-Debug -Message ('Days Valid:              {0}' -f $daysValid)
+        Write-Debug -Message ('Max Days Valid:          {0}' -f $MaxDaysValid)
+        if( $daysValid -gt $MaxDaysValid )
+        {
+            Write-Debug -Message ('Adjusted Days Valid:     {0}' -f $daysValid)
+            $daysValid = $MaxDaysValid
+        }
+        (@'
+[Version]
+Signature = "$Windows NT$"
+
+[Strings]
+szOID_ENHANCED_KEY_USAGE = "2.5.29.37"
+szOID_DOCUMENT_ENCRYPTION = "1.3.6.1.4.1.311.80.1"
+
+[NewRequest]
+Subject = "{0}"
+MachineKeySet = false
+KeyLength = {1}
+KeySpec = AT_KEYEXCHANGE
+HashAlgorithm = {2}
+Exportable = true
+RequestType = Cert
+KeyUsage = "CERT_KEY_ENCIPHERMENT_KEY_USAGE | CERT_DATA_ENCIPHERMENT_KEY_USAGE"
+ValidityPeriod = Days
+ValidityPeriodUnits = {3}
+
+[Extensions]
+%szOID_ENHANCED_KEY_USAGE% = "{{text}}%szOID_DOCUMENT_ENCRYPTION%"
+'@ -f $Subject,$Length,$Algorithm,$daysValid) | Set-Content -Path $tempInfFile
+
+        Get-Content -Raw -Path $tempInfFile | Write-Debug
+
+        $output = & $certReqPath -q -new $tempInfFile $PublicKeyFile 
+        if( $LASTEXITCODE -or -not (Test-Path -Path $PublicKeyFile -PathType Leaf) )
+        {
+            Write-Error ('Failed to create public/private key pair:{0}{1}' -f ([Environment]::NewLine),($output -join ([Environment]::NewLine)))
+            return
+        }
+        else
+        {
+            $output | Write-Debug
+        }
+
+        $publicKey = Get-CCertificate -Path $PublicKeyFile
+        if( -not $publicKey )
+        {
+            Write-Error ('Failed to load public key ''{0}'':{1}{2}' -f $PublicKeyFile,([Environment]::NewLine),($output -join ([Environment]::NewLine)))
+            return
+        }
+
+        $privateCertPath = Join-Path -Path 'cert:\CurrentUser\My' -ChildPath $publicKey.Thumbprint
+        if( -not (Test-Path -Path $privateCertPath -PathType Leaf) )
+        {
+            Write-Error -Message ('Private key ''{0}'' not found. Did certreq.exe fail to install the private key there?' -f $privateCertPath)
+            return
+        }
+
+        try
+        {
+            $privateCert = Get-Item -Path $privateCertPath
+            if( -not $privateCert.HasPrivateKey )
+            {
+                Write-Error -Message ('Certificate ''{0}'' doesn''t have a private key.' -f $privateCertPath)
+                return
+            }
+
+            if( -not $PSBoundParameters.ContainsKey('Password') )
+            {
+                $Password = Read-Host -Prompt 'Enter private key password' -AsSecureString
+            }
+
+            $privateCertBytes = $privateCert.Export( 'PFX', $Password )
+            [IO.File]::WriteAllBytes( $PrivateKeyFile, $privateCertBytes )
+
+            Get-Item $PublicKeyFile
+            Get-Item $PrivateKeyFile
+        }
+        finally
+        {
+            Remove-Item -Path $privateCertPath
+        }
+    }
+    finally
+    {
+        Remove-Item -Path $tempDir -Recurse
+    }
+}

--- a/Tests/New-CRsaKeyPair.Tests.ps1
+++ b/Tests/New-CRsaKeyPair.Tests.ps1
@@ -1,0 +1,230 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Set-StrictMode -Version 'Latest'
+
+BeforeAll {
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
+
+    $script:testDir = $null
+    $script:testNum = 0
+    $script:privateKeyPassword = ConvertTo-SecureString -String 'fubarsnafu' -AsPlainText -Force
+    $script:subject = $null
+    $script:publicKeyPath = $null
+    $script:privateKeyPath = $null
+
+    function Assert-KeyProperty
+    {
+        param(
+            $Length = 4096,
+            [datetime]
+            $ValidTo,
+            $Algorithm = 'sha512RSA'
+        )
+
+        Set-StrictMode -Version 'Latest'
+
+        if( -not $ValidTo )
+        {
+            $ValidTo = (Get-Date).AddDays( [Math]::Floor(([DateTime]::MaxValue - [DateTime]::UtcNow).TotalDays) )
+        }
+
+        $cert = Get-CCertificate -Path $script:publicKeyPath
+        # Weird date/time stamps in generated certificate that I can't figure out/replicate. So we'll just check that
+        # the expected/actual dates are within a day of each other.
+        [timespan]$span = $ValidTo - $cert.NotAfter
+        $span.TotalDays | Should -BeGreaterThan (-2)
+        $span.TotalDays | Should -BeLessThan 2
+        $cert.Subject | Should -Be $script:subject
+        $cert.PublicKey.Key.KeySize | Should -Be $Length
+        $cert.PublicKey.Key.KeyExchangeAlgorithm | Should -BeLike 'RSA*'
+        $cert.SignatureAlgorithm.FriendlyName | Should -Be $Algorithm
+        $keyUsage = $cert.Extensions | Where-Object { $_ -is [Security.Cryptography.X509Certificates.X509KeyUsageExtension] }
+        $keyUsage | Should -Not -BeNullOrEmpty
+        $keyUsage.KeyUsages.HasFlag([Security.Cryptography.X509Certificates.X509KeyUsageFlags]::DataEncipherment) |
+            Should -BeTrue
+        $keyUsage.KeyUsages.HasFlag([Security.Cryptography.X509Certificates.X509KeyUsageFlags]::KeyEncipherment) |
+            Should -BeTrue
+        $enhancedKeyUsage =
+            $cert.Extensions |
+            Where-Object { $_ -is [Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension] }
+        $enhancedKeyUsage | Should -Not -BeNullOrEmpty
+
+        # I don't think Windows 2008 supports Enhanced Key Usages.
+        $osVersion = (Get-WmiObject -Class 'Win32_OperatingSystem').Version
+        if( $osVersion -notmatch '6.1\b' )
+        {
+            $usage = $enhancedKeyUsage.EnhancedKeyUsages | Where-Object { $_.FriendlyName -eq 'Document Encryption' }
+            $usage | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'New-RsaKeyPair' {
+    BeforeEach {
+        $script:testDir = Join-Path -Path $TestDrive -ChildPath ($script:testNum++)
+        $Global:Error.Clear()
+
+        $script:subject = 'CN={0}' -f [Guid]::NewGuid()
+        $script:publicKeyPath = Join-Path -Path $script:testDir -ChildPath 'public.cer'
+        $script:privateKeyPath = Join-Path -Path $script:testDir -ChildPath 'private.pfx'
+    }
+
+    It 'should generate a public/private key pair' {
+        $output = New-CRsaKeyPair -Subject $script:subject `
+                                  -PublicKeyFile $script:publicKeyPath `
+                                  -PrivateKeyFile $script:privateKeyPath `
+                                  -Password $script:privateKeyPassword
+        $output | Should -Not -BeNullOrEmpty
+        $output.Count | Should -Be 2
+
+        $script:publicKeyPath | Should -Exist
+        $output[0].FullName | Should -Be $script:publicKeyPath
+
+        $script:privateKeyPath | Should -Exist
+        $output[1].FullName | Should -Be $script:privateKeyPath
+
+        Assert-KeyProperty
+    }
+
+    It 'should generate a key usable by DSC' -Skip:($PSVersionTable['PSEdition'] -eq 'Core') {
+        $output = New-CRsaKeyPair -Subject $script:subject `
+                                  -PublicKeyFile $script:publicKeyPath `
+                                  -PrivateKeyFile $script:privateKeyPath `
+                                  -Password $script:privateKeyPassword
+        # Make sure we can decrypt things with it.
+        $secret = [IO.Path]::GetRandomFileName()
+        $protectedSecret = Protect-CString -String $secret -Certificate $script:publicKeyPath
+        $decryptedSecret = Unprotect-CString -ProtectedString $protectedSecret `
+                                             -PrivateKeyPath $script:privateKeyPath `
+                                             -Password $script:privateKeyPassword `
+                                             -AsPlainText
+
+        $decryptedSecret | Should -Be $secret
+
+        $publicKey = Get-CCertificate -Path $script:publicKeyPath
+        $publicKey | Should -Not -BeNullOrEmpty
+
+        # Make sure it works with DSC
+        $configData = @{
+            AllNodes = @(
+                @{
+                    NodeName = 'localhost';
+                    CertificateFile = $script:publicKeyPath;
+                    Thumbprint = $publicKey.Thumbprint;
+                }
+            )
+        }
+
+        configuration TestEncryption
+        {
+            Set-StrictMode -Off
+
+            node $AllNodes.NodeName
+            {
+                User 'CreateDummyUser'
+                {
+                    UserName = 'fubarsnafu';
+                    Password =
+                        ([pscredential]::New('fubarsnafu', (ConvertTo-SecureString 'Password1' -AsPlainText -Force)))
+                }
+            }
+        }
+
+        & TestEncryption -ConfigurationData $configData -OutputPath $script:testDir
+
+        # DSC will silently write errors if this key doesn't exist even though no functionality is impacted by the
+        # missing key.
+        $dscRegKey = 'HKLM:\SOFTWARE\Microsoft\PowerShell\3\DSC'
+        $dscRegKeyErrorMessages =
+            $Global:Error |
+            Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } |
+            Where-Object { $_.Exception.Message -like ('*Cannot find path ''{0}''*' -f $dscRegKey) }
+
+        foreach ($error in $dscRegKeyErrorMessages)
+        {
+            $Global:Error.Remove($error)
+        }
+
+        $Global:Error.Count | Should -Be 0
+        $mofPath = Join-Path -Path $script:testDir -ChildPath 'localhost.mof'
+        Get-Content -Path $mofPath -Raw | Write-Debug
+        $mofPath | Should -Not -Contain 'Password1'
+    }
+
+    It 'should generate key pairs that can be used by CMS cmdlets' `
+       -Skip:(-not (Get-Command -Name 'Protect-CmsMessage' -ErrorAction Ignore)) {
+        $output = New-CRsaKeyPair -Subject $script:subject `
+                                  -PublicKeyFile $script:publicKeyPath `
+                                  -PrivateKeyFile $script:privateKeyPath `
+                                  -Password $script:privateKeyPassword
+
+        $cert = Install-CCertificate -Path $script:privateKeyPath `
+                                     -StoreLocation CurrentUser `
+                                     -StoreName My `
+                                     -Password $script:privateKeyPassword `
+                                     -PassThru
+
+        try
+        {
+            $message = 'fubarsnafu'
+            $protectedMessage = Protect-CmsMessage -To $script:publicKeyPath -Content $message
+            Unprotect-CmsMessage -Content $protectedMessage | Should -Be $message
+        }
+        finally
+        {
+            Uninstall-CCertificate -Thumbprint $cert.Thumbprint -StoreLocation CurrentUser -StoreName My
+        }
+    }
+
+    It 'should generate key with custom configuration' {
+        $validTo = [datetime]::Now.AddDays(30)
+        $length = 2048
+
+        $output = New-CRsaKeyPair -Subject $script:subject `
+                                  -PublicKeyFile $script:publicKeyPath `
+                                  -PrivateKeyFile $script:privateKeyPath `
+                                  -Password $script:privateKeyPassword `
+                                  -ValidTo $validTo `
+                                  -Length $length `
+                                  -Algorithm sha1
+
+        Assert-KeyProperty -Length $length -ValidTo $validTo -Algorithm 'sha1RSA'
+
+    }
+
+    It 'should reject subjects that don''t begin with CN=' {
+        {
+            New-CRsaKeyPair -Subject 'fubar' `
+                            -PublicKeyFile $script:publicKeyPath `
+                            -PrivateKeyFile $script:privateKeyPath `
+                            -Password $script:privateKeyPassword
+        } | Should -Throw
+        $Global:Error[0] | Should -Match 'does not match'
+    }
+
+    It 'should not protect private key' {
+        $output = New-CRsaKeyPair -Subject $script:subject `
+                                  -PublicKeyFile $script:publicKeyPath `
+                                  -PrivateKeyFile $script:privateKeyPath `
+                                  -Password $null
+        $output.Count | Should -Be 2
+
+        $privateKey = Get-CCertificate -Path $script:privateKeyPath
+        $privateKey | Should -Not -BeNullOrEmpty
+
+        $secret = [IO.Path]::GetRandomFileName()
+        $protectedSecret = Protect-CString -String $secret -PublicKeyPath $script:publicKeyPath
+        Unprotect-CString -ProtectedString $protectedSecret -PrivateKeyPath $script:privateKeyPath -AsPlainText |
+            Should -Be $secret
+    }
+}

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -82,13 +82,26 @@ Build:
             - "*\\Get-CCertificate.Tests.ps1"
             - "*\\Import-Carbon.Cryptography.Tests.ps1"
             - "*\\Install-CCertificate.Tests.ps1"
+            - "*\\New-CRsaKeyPair.Tests.ps1"
             - "*\\Protect-CString.Tests.ps1"
             - "*\\Uninstall-CCertificate.Tests.ps1"
             - "*\\Unprotect-CString.Tests.ps1"
-            Exit: true
+            Throw: true
         TestResult:
             Enabled: true
             OutputPath: .output\pester5.xml
+        Output: Detailed
+
+- Pester:
+    # Because the DSC resource in the test is resolved during parsing not execution.
+    OnlyOnPlatform: Windows
+    Configuration:
+        Run:
+            Path: Tests\New-CRsaKeyPair.Tests.ps1
+            Throw: true
+        TestResult:
+            Enabled: true
+            OutputPath: .output\pester5-new-crsakeypair.xml
         Output: Detailed
 
 - Pester4:


### PR DESCRIPTION
We needed to update New-CRsaKeyPair to support generating signing certificates. so migrated `New-CRsaKeyPair` from Carbon, then added signing key support.