### PR TITLE
Dispose certificates read from a file as soon as we're done with them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 # Carbon.Cryptography Changelog
 
+## 3.2.0
+
+> Released 17 Oct 2023
+
+When reading certificates from a file, the module now disposes references to those certificates as soon it is done with
+them. This limits the amount of time a certificate's private key spends on disk when the certificate has been loaded
+from a file.
+
 ## 3.1.3
 
 > Released 26 Apr 2023

--- a/Carbon.Cryptography/Carbon.Cryptography.psd1
+++ b/Carbon.Cryptography/Carbon.Cryptography.psd1
@@ -17,7 +17,7 @@
     RootModule = 'Carbon.Cryptography.psm1'
 
     # Version number of this module.
-    ModuleVersion = '3.1.3'
+    ModuleVersion = '3.2.0'
 
     # ID used to uniquely identify this module
     GUID = '225b9f63-3e3e-406c-87a0-33d34f30cd8e'


### PR DESCRIPTION
When loading a certificate from a file, Windows will temporarily write the private key to disk for the lifetime of the certificate object. To limit the amount of time the private key spends on disk, dispose the certificate object as soon as we are done with it.