### PR TITLE
Feature/support wildcard certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@
 /Carbon.Cryptography/*.md
 /Carbon.Cryptography/LICENSE
 /Carbon.Cryptography/NOTICE
-/Tests/
+/Tests/.password
+/Tests/PASSWORD
+/Tests/private.pfx
+/Tests/public.cer
 output

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 /PSModules/
 /.vscode/
 /Carbon.Cryptography/PSModules/
-/Tests/.password
+/Carbon.Cryptography/*.md
+/Carbon.Cryptography/LICENSE
+/Carbon.Cryptography/NOTICE
+/Tests/
+output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 # Carbon.Cryptography Changelog
 
+## 3.3.0
+
+> Released 29 Jan 2024
+
+`Find-CCertificate` and `Find-CTlsCertificate` now support finding certificates with a Subject Alternative Name that
+contains a wildcard that matches the given `HostName`. For example: Passing `test.example.com` to the `HostName` parameter
+will return a certificate whose Subject Alternative Name contains `*.example.com`.
+
 ## 3.2.0
 
 > Released 17 Oct 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 3.3.0
 
-> Released 29 Jan 2024
+> Released 30 Jan 2024
 
 `Find-CCertificate` and `Find-CTlsCertificate` now support finding certificates with a Subject Alternative Name that
 contains a wildcard that matches the given `HostName`. For example: Passing `test.example.com` to the `HostName` parameter

--- a/Carbon.Cryptography/Carbon.Cryptography.psd1
+++ b/Carbon.Cryptography/Carbon.Cryptography.psd1
@@ -17,7 +17,7 @@
     RootModule = 'Carbon.Cryptography.psm1'
 
     # Version number of this module.
-    ModuleVersion = '3.2.0'
+    ModuleVersion = '3.3.0'
 
     # ID used to uniquely identify this module
     GUID = '225b9f63-3e3e-406c-87a0-33d34f30cd8e'

--- a/Carbon.Cryptography/Functions/Find-CCertificate.ps1
+++ b/Carbon.Cryptography/Functions/Find-CCertificate.ps1
@@ -184,12 +184,12 @@ function Find-CCertificate
 
                 foreach ($nameItem in $InputObject)
                 {
-                    if ($nameItem -match '\*')
+                    if ($nameItem[0] -eq '*')
                     {
                         # Wildcards in certificates only ever match one "level" of a domain name and must be on the very left.
                         # Therefore the wildcard can match any character except for "."
                         $wildcardRegex = '[^\.]+'
-                        $baseName = $nameItem -replace '^\*', ''      # *.example.com  ➔ .example.com
+                        $baseName = $nameItem.Substring(1)               # *.example.com  ➔ .example.com
                         $escapedBaseName = [Regex]::Escape($baseName)    #  .example.com  ➔ \.example\.com
                         $regex = "^${wildcardRegex}$($escapedBaseName)$" # \.example\.com ➔ ^[^\.]+\.example\.com$
                         $success = $Value -match $regex

--- a/Carbon.Cryptography/Functions/Find-CCertificate.ps1
+++ b/Carbon.Cryptography/Functions/Find-CCertificate.ps1
@@ -180,7 +180,26 @@ function Find-CCertificate
             }
             elseif( $ContainsLike )
             {
-                $success = $null -ne ($InputObject | Where-Object { $_ -like $Value })
+                $success = $false
+
+                foreach ($nameItem in $InputObject)
+                {
+                    if ($nameItem -match '\*')
+                    {
+                        # Wildcards in certificates only ever match one "level" of a domain name and must be on the very left.
+                        # Therefore the wildcard can match any character except for "."
+                        $wildcardRegex = '[^\.]+'
+                        $baseName = $nameItem -replace '^\*', ''      # *.example.com  ➔ .example.com
+                        $escapedBaseName = [Regex]::Escape($baseName)    #  .example.com  ➔ \.example\.com
+                        $regex = "^${wildcardRegex}$($escapedBaseName)$" # \.example\.com ➔ ^[^\.]+\.example\.com$
+                        $success = $Value -match $regex
+                    }
+                    else
+                    {
+                        $success = $nameItem -like $Value
+                    }
+                }
+
             }
             elseif( $Match )
             {

--- a/Tests/Find-CCertificate.Tests.ps1
+++ b/Tests/Find-CCertificate.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
             [String[]] $WithDnsNames = @(),
 
             [String[]] $WithKeyUsageNames = @(),
-            
+
             [String[]] $WithKeyUsageOids = @(),
 
             [switch] $ThatIsTrusted,
@@ -171,6 +171,19 @@ Describe 'Find-CCertificate' {
         GivenCertificate -For 'CN=example.com' -WithDnsNames @('example.com', 'nine.example.com')
         WhenFinding @{ HostName = '*.example.com' }
         ThenFound 'CN=example.com'
+    }
+
+    It 'should find hostname using subject alternate name with wildcard' {
+        GivenCertificate -For 'CN=*.test.example.com' -WithDnsNames @('*.test.example.com')
+        GivenCertificate -For 'CN=andnot.example.com' -WithDnsNames @('*.example.com')
+        WhenFinding @{ HostName = 'fourteen.test.example.com' }
+        ThenFound 'CN=*.test.example.com'
+    }
+
+    It 'should find wildcard hostname using subject alternate name with wildcard' {
+        GivenCertificate -For 'CN=*.example.com' -WithDnsNames @('*.example.com')
+        WhenFinding @{ HostName = '*.example.com' }
+        ThenFound 'CN=*.example.com'
     }
 
     It 'should find literal hostname that matches subject common name' {

--- a/Tests/Find-CTlsCertificate.Tests.ps1
+++ b/Tests/Find-CTlsCertificate.Tests.ps1
@@ -160,7 +160,7 @@ Describe 'Find-CTlsCertificate' {
     }
 
     It 'should find the certificate when subject alternate name matches' {
-        GivenCertificate -For $env:COMPUTERNAME -WithDnsNames ('fake.net', 'fake2.net')
+        GivenCertificate -For [Environment]::MachineName -WithDnsNames ('fake.net', 'fake2.net')
         WhenFindingTlsCertificate 'fake2.net'
         ThenFoundCertificate
     }

--- a/Tests/Find-CTlsCertificate.Tests.ps1
+++ b/Tests/Find-CTlsCertificate.Tests.ps1
@@ -167,7 +167,7 @@ Describe 'Find-CTlsCertificate' {
 
     It 'should find the certificate when subject alternate name matches wildcard' {
         GivenCertificate -For 'localhost' -WithDnsNames ('*.example.com')
-        WhenFindingTlsCertificate 'test.example.com' -Verbose
+        WhenFindingTlsCertificate 'test.example.com'
         ThenFoundCertificate
     }
 

--- a/Tests/Find-CTlsCertificate.Tests.ps1
+++ b/Tests/Find-CTlsCertificate.Tests.ps1
@@ -66,7 +66,7 @@ BeforeAll {
         [void] $script:mockedCertificates.Add($mockCert)
     }
 
-    function ThenFoundCertificate 
+    function ThenFoundCertificate
     {
         param(
             [String] $WithThumbprint
@@ -124,7 +124,7 @@ BeforeAll {
         {
             $optionalParams['Trusted'] = $ThatIsTrusted
         }
-        
+
         $script:foundCert = Find-CTlsCertificate @optionalParams
     }
 }
@@ -150,29 +150,35 @@ Describe 'Find-CTlsCertificate' {
         GivenCertificate -For 'does not match hostname'
         GivenCertificate -For 'also does not match hostname'
         WhenFindingTlsCertificate 'example.com' -ErrorAction SilentlyContinue
-        ThenNoCertificateFound 
+        ThenNoCertificateFound
     }
 
     It 'should not find a certificate when no private key exists' {
         GivenCertificate -For 'noprivatekey.com' -WithNoPrivateKey
         WhenFindingTlsCertificate 'noprivatekey.com' -ErrorAction SilentlyContinue
-        ThenNoCertificateFound 
+        ThenNoCertificateFound
     }
 
     It 'should find the certificate when subject alternate name matches' {
-        GivenCertificate -For $machineName -WithDnsNames ('fake.net', 'fake2.net')
+        GivenCertificate -For $env:COMPUTERNAME -WithDnsNames ('fake.net', 'fake2.net')
         WhenFindingTlsCertificate 'fake2.net'
         ThenFoundCertificate
     }
 
+    It 'should find the certificate when subject alternate name matches wildcard' {
+        GivenCertificate -For 'localhost' -WithDnsNames ('*.example.com')
+        WhenFindingTlsCertificate 'test.example.com' -Verbose
+        ThenFoundCertificate
+    }
+
     It 'should not find a certificate when key usage is not Server Authentication' {
-        GivenCertificate -For 'invalidkeyusage.com' -WithUsages ('Remote Desktop Authentication', 'Client Authentication') 
+        GivenCertificate -For 'invalidkeyusage.com' -WithUsages ('Remote Desktop Authentication', 'Client Authentication')
         WhenFindingTlsCertificate 'invalidkeyusage.com' -ErrorAction SilentlyContinue
-        ThenNoCertificateFound 
+        ThenNoCertificateFound
     }
 
     It 'should not find a certificate when key usage is Server Authentication' {
-        GivenCertificate -For 'validkeyusage.com' -WithUsages ('Remote Desktop Authentication', 'Server Authentication') 
+        GivenCertificate -For 'validkeyusage.com' -WithUsages ('Remote Desktop Authentication', 'Server Authentication')
         WhenFindingTlsCertificate 'validkeyusage.com'
         ThenFoundCertificate
     }
@@ -192,7 +198,7 @@ Describe 'Find-CTlsCertificate' {
     It 'should not find a certificate when certificate is expired' {
         GivenCertificate -For 'expired.com' -ThatExpires (Get-Date).AddDays(-1)
         WhenFindingTlsCertificate 'expired.com' -ErrorAction SilentlyContinue
-        ThenNoCertificateFound 
+        ThenNoCertificateFound
     }
 
     It 'should not find a certificate when certificate has not started' {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,13 @@ test: off
 environment:
   WHISKEY_DISABLE_ERROR_FORMAT: True
   matrix:
-  - job_name: PowerShell 7.2 on Windows
-    job_group: pwsh
-    appveyor_build_worker_image: Visual Studio 2022
+  # Skip PowerShell Core on Windows until 7.4.1 is installed
+  # on https://www.appveyor.com/docs/windows-images-software
+  # Due to https://github.com/PowerShell/PowerShell/issues/20711
+
+  # - job_name: PowerShell 7.2 on Windows
+  #   job_group: pwsh
+  #   appveyor_build_worker_image: Visual Studio 2022
 
   - job_name: PowerShell 7.1 on macOS
     job_group: pwsh
@@ -36,9 +40,9 @@ environment:
     job_group: pwsh
     appveyor_build_worker_image: Ubuntu
 
-  - job_name: PowerShell 7.1 on Windows
-    job_group: pwsh
-    appveyor_build_worker_image: Visual Studio 2019
+  # - job_name: PowerShell 7.1 on Windows
+  #   job_group: pwsh
+  #   appveyor_build_worker_image: Visual Studio 2019
 
 
 artifacts:
@@ -52,6 +56,7 @@ for:
     - job_group: ps
   build_script:
   - ps: |
+        $PSVersionTable
         $ProgressPreference = 'SilentlyContinue'
         $url = 'https://raw.githubusercontent.com/webmd-health-services/Prism/main/Scripts/init.ps1'
         $headers = @{ Authentication = "Bearer $($env:GITHUB_ACCESS_TOKEN)" }
@@ -64,6 +69,7 @@ for:
     - job_group: pwsh
   build_script:
   - pwsh: |
+        $PSVersionTable
         $ProgressPreference = 'SilentlyContinue'
         $url = 'https://raw.githubusercontent.com/webmd-health-services/Prism/main/Scripts/init.ps1'
         $headers = @{ Authentication = "Bearer $($env:GITHUB_ACCESS_TOKEN)" }


### PR DESCRIPTION
`Find-CCertificate` and `Find-CTlsCertificate` now support finding certificates with a Subject Alternative Name that
contains a wildcard that matches the given `HostName`. For example: Passing `test.example.com` to the `HostName` parameter
will return a certificate whose Subject Alternative Name contains `*.example.com`.