### PR TITLE
Fixed: Find-CCertificate fails to find by hostname if the hostname is…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 
 # Carbon.Cryptography Changelog
 
+## 3.4.4
+
+* Fixed: `Find-CCertificate` and `Find-CTlsCertificate` fail to find a certificate by hostname if the hostname isn't
+  the last or only item in a certificate's list of subject alternate names.
+
 ## 3.4.3
+
+> Released 10 Dec 2024
 
 Removing extra nested module scope.
 

--- a/Carbon.Cryptography/Carbon.Cryptography.psd1
+++ b/Carbon.Cryptography/Carbon.Cryptography.psd1
@@ -17,7 +17,7 @@
     RootModule = 'Carbon.Cryptography.psm1'
 
     # Version number of this module.
-    ModuleVersion = '3.4.3'
+    ModuleVersion = '3.4.4'
 
     # ID used to uniquely identify this module
     GUID = '225b9f63-3e3e-406c-87a0-33d34f30cd8e'

--- a/Carbon.Cryptography/Functions/Find-CCertificate.ps1
+++ b/Carbon.Cryptography/Functions/Find-CCertificate.ps1
@@ -184,6 +184,7 @@ function Find-CCertificate
 
                 foreach ($nameItem in $InputObject)
                 {
+                    # If the first character of the item is a wildcard character.
                     if ($nameItem[0] -eq '*')
                     {
                         # Wildcards in certificates only ever match one "level" of a domain name and must be on the very left.
@@ -197,6 +198,12 @@ function Find-CCertificate
                     else
                     {
                         $success = $nameItem -like $Value
+                    }
+
+                    # Found a match.
+                    if ($success)
+                    {
+                        break
                     }
                 }
 

--- a/Tests/Find-CCertificate.Tests.ps1
+++ b/Tests/Find-CCertificate.Tests.ps1
@@ -180,6 +180,12 @@ Describe 'Find-CCertificate' {
         ThenFound 'CN=*.test.example.com'
     }
 
+    It 'finds certificate by penultimate subject alternate name' {
+        GivenCertificate -For 'CN=*.carbon' -WithDnsNames @('*.one.carbon', '*.two.carbon')
+        WhenFinding @{ HostName = '*.one.carbon' }
+        ThenFound 'CN=*.carbon'
+    }
+
     It 'should find wildcard hostname using subject alternate name with wildcard' {
         GivenCertificate -For 'CN=*.example.com' -WithDnsNames @('*.example.com')
         WhenFinding @{ HostName = '*.example.com' }


### PR DESCRIPTION
…n't the last or only hostname in the certificate's list of subject alternate names.