### PR TITLE
Bugfix/unprotect file token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 > Released 29 Jul 2025
 
 * Fixed: `Unprotect-CFileToken` fails when `OutputPath` is a relative path.
+* Fixed: `Unprotect-CFileToken` shouldn't require `Force` when `OutputPath` already exists but is empty.
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 # Carbon.Cryptography Changelog
 
+## 3.5.1
+
+> Released 29 Jul 2025
+
+* Fixed: `Unprotect-CFileToken` fails when `OutputPath` is a relative path.
+
 ## 3.5.0
 
 > Released 15 Jul 2025

--- a/Carbon.Cryptography/Carbon.Cryptography.psd1
+++ b/Carbon.Cryptography/Carbon.Cryptography.psd1
@@ -17,7 +17,7 @@
     RootModule = 'Carbon.Cryptography.psm1'
 
     # Version number of this module.
-    ModuleVersion = '3.5.0'
+    ModuleVersion = '3.5.1'
 
     # ID used to uniquely identify this module
     GUID = '225b9f63-3e3e-406c-87a0-33d34f30cd8e'

--- a/Carbon.Cryptography/Functions/Unprotect-CFileToken.ps1
+++ b/Carbon.Cryptography/Functions/Unprotect-CFileToken.ps1
@@ -140,6 +140,11 @@ function Unprotect-CFileToken
         return
     }
 
+    if (-not ([IO.Path]::IsPathRooted($OutputPath)))
+    {
+        $OutputPath = Join-Path -Path (Get-Location) -ChildPath $OutputPath
+    }
+
     if ((Test-Path -LiteralPath $OutputPath) -and (-not $Force))
     {
         $msg = "OutputPath file ""${OutputPath}"" already exists. Use the -Force switch to overwrite."

--- a/Carbon.Cryptography/Functions/Unprotect-CFileToken.ps1
+++ b/Carbon.Cryptography/Functions/Unprotect-CFileToken.ps1
@@ -145,11 +145,14 @@ function Unprotect-CFileToken
         $OutputPath = Join-Path -Path (Get-Location) -ChildPath $OutputPath
     }
 
-    if ((Test-Path -LiteralPath $OutputPath) -and (-not $Force))
+    if (Test-Path -LiteralPath $OutputPath)
     {
-        $msg = "OutputPath file ""${OutputPath}"" already exists. Use the -Force switch to overwrite."
-        Write-Error $msg -ErrorAction $ErrorActionPreference
-        return
+        if (((Get-Item -LiteralPath $OutputPath).Length -ne 0) -and (-not $Force))
+        {
+            $msg = "OutputPath file ""${OutputPath}"" already exists and isn't empty. Use the -Force switch to overwrite."
+            Write-Error $msg -ErrorAction $ErrorActionPreference
+            return
+        }
     }
 
     $fileContent = Get-Content -LiteralPath $Path -Raw

--- a/Tests/Unprotect-CFileToken.Tests.ps1
+++ b/Tests/Unprotect-CFileToken.Tests.ps1
@@ -50,8 +50,12 @@ BeforeAll {
         )
 
         $filePath = Join-Path -Path $script:testDir -ChildPath $Path
-        New-Item -Path ($filePath | Split-Path -Parent) -ItemType Directory -Force | Write-Debug
-        [IO.File]::WriteAllText($filePath, $Content)
+        New-Item -Path $filePath -ItemType File -Force | Write-Debug
+
+        if ($Content)
+        {
+            [IO.File]::WriteAllText($filePath, $Content)
+        }
     }
 
     function ThenFile
@@ -183,7 +187,7 @@ password = ${secret}
 password = !ENCRYPTED:${cipherText}!
 "@
             { WhenUnprotectingFileToken -Path 'config.txt' -OutputPath 'config.txt' -ErrorAction Stop } |
-                Should -Throw 'OutputPath file "*config.txt" already exists. Use the -Force switch to overwrite.'
+                Should -Throw 'OutputPath file "*config.txt" already exists and isn''t empty. Use the -Force switch to overwrite.'
         }
 
         It 'should succeed when OutputPath exists and using Force' {
@@ -421,6 +425,20 @@ password = !ENCRYPTED:${cipherText}!
 
         ThenFile 'config.txt.decrypted' @"
 password = ${secret}
+"@
+        ThenNoError
+    }
+
+    It 'should not require Force when OutputPath exists but is empty' {
+        $secret = 'hunter2'
+        $cipherText = Protect-CString -String $secret -PublicKeyPath $script:publicKeyPath
+        GivenFile 'config.txt' @"
+password = !ENCRYPTED:${cipherText}!
+"@
+        GivenFile 'empty.txt'
+        WhenUnprotectingFileToken -Path 'config.txt' -OutputPath 'empty.txt' -PrivateKeyPath $script:privateKeyUnprotectedPath
+        ThenFile 'empty.txt' @"
+password = hunter2
 "@
         ThenNoError
     }

--- a/Tests/Unprotect-CFileToken.Tests.ps1
+++ b/Tests/Unprotect-CFileToken.Tests.ps1
@@ -402,4 +402,26 @@ key = ${secret}
             ThenNoError
         }
     }
+
+    It 'should write to the correct path when given a relative output path' {
+        $secret = 'hunter2'
+        $cipherText = Protect-CString -String $secret -PublicKeyPath $script:publicKeyPath
+        GivenFile 'config.txt' @"
+password = !ENCRYPTED:${cipherText}!
+"@
+        Push-Location $script:testDir
+        try
+        {
+            Unprotect-CFileToken -Path 'config.txt' -OutputPath 'config.txt.decrypted' -PrivateKeyPath $script:privateKeyUnprotectedPath
+        }
+        finally
+        {
+            Pop-Location
+        }
+
+        ThenFile 'config.txt.decrypted' @"
+password = ${secret}
+"@
+        ThenNoError
+    }
 }


### PR DESCRIPTION
* Fixed: `Unprotect-CFileToken` fails when `OutputPath` is a relative path.
* Fixed: `Unprotect-CFileToken` shouldn't require `Force` when `OutputPath` already exists but is empty.